### PR TITLE
Fix typos from Tom, Fix <ins> (NFC)

### DIFF
--- a/P1072.bs
+++ b/P1072.bs
@@ -65,9 +65,8 @@ This proposal addresses the problem by adding
 `basic_string::resize_default_init`:
 
 <blockquote>
-<ins>
 <pre highlight="">
-template<typename Operation>
+template&lt;typename Operation&gt;
 void resize_default_init(size_type n, Operation op);
 </pre>
 <ol start="8">
@@ -84,7 +83,6 @@ void resize_default_init(size_type n, Operation op);
     ([**expr.ass**]) values in the range `[data(), data()+m)`.
 </li>
 </ol>
-</ins>
 </blockquote>
 
 In order to enable `resize_default_init`, this proposal makes it
@@ -659,8 +657,8 @@ In [**basic.string**] [20.3.2], in the synopsis, add
     size_type max_size() const noexcept;
     void resize(size_type n, charT c);
     void resize(size_type n);
-    <ins>template<typename Operation>
-    void resize_default_init(size_type n, Operation op);</ins>
+    <ins>template&lt;typename Operation&gt;</ins>
+    <ins>void resize_default_init(size_type n, Operation op);</ins>
     size_type capacity() const noexcept;
     void reserve(size_type res_arg);
     void shrink_to_fit();
@@ -688,15 +686,11 @@ and `destroy`.
   `traits::char_type` is not the same type as `charT`. &mdash; *end
   note*]
 
-<ins>
-
-4. `basic_string` is an allocator-aware container as described in
-  [container.requirements.general], except that it is
+4. <ins> `basic_string` is an allocator-aware container as described
+  in [container.requirements.general], except that it is
   implementation-defined whether `allocator_traits::construct` and
   `allocator_traits::destroy` are used to construct and destroy the
-  contained `charT` objects.
-
-</ins>
+  contained `charT` objects. </ins>
 
 5. References, pointers, and iterators referring to the elements of a
   `basic_string` sequence may be invalidated by the following uses of
@@ -728,28 +722,25 @@ void resize(size_type n);
 <li>*Effects:* Equivalent to `resize(n, charT())`.</li>
 </ol>
 
-<ins>
-<pre highlight="">
-void resize_default_init(size_type n);
-</pre>
+<pre highlight=""><ins>
+template&lt;typename Operation&gt;
+void resize_default_init(size_type n, Operation op);
+</ins></pre>
 
 <ol start="8">
 
-<li>*Effects:* Alters the value of `*this` as follows:
+<li><ins>*Effects:* Alters the value of `*this` as follows:</ins>
      <ol>
-     <li>— If `n <= size()`, erases the last `size() - n` elements.</li>
-     <li>— If `n > size()`, appends `n - size()` default-initialized
-         elements.</li>
+     <li><ins>— If `n <= size()`, erases the last `size() - n`
+     elements.</ins></li>
+     <li><ins>— If `n > size()`, appends `n - size()`
+         default-initialized elements.</ins></li>
      </ol>
 </li>
-<li>*Remarks:* Let `m = op(data(), n)`. `op` shall replace
+<li><ins>*Remarks:* Let `m = op(data(), n)`. `op` shall replace
     ([**expr.ass**]) the values stored in the character array
-    `[data(), data()+m)`.
-</li>
+    `[data(), data()+m)`.</ins></li>
 </ol>
-
-</ins>
-</pre>
 
 <pre highlight="">
 size_type capacity() const noexcept;
@@ -788,7 +779,7 @@ We can then simplify p15:
     except `array` meet the additional requirements of an
     allocator-aware container, as</del> <ins> Allocator-aware
     containers meet the additional requirements described in Table
-    67.</li>
+    67.</ins></li>
 
 </ol>
 </blockquote>


### PR DESCRIPTION
Tom pointed out a number of typos where we failed to escape < and > and
where we had not updated wording to match the proposal. Those are fixed.

Also, I noticed that `<ins>` stapped working the way it used to. To fix
things I had to scatter `<ins>` `</ins>` everywhere